### PR TITLE
feat: Implementert Darkside

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "aksel-konsultasjon",
       "version": "0.0.0",
       "dependencies": {
-        "@navikt/ds-css": "^7.24.0",
+        "@navikt/ds-css": "^7.25.1",
         "@navikt/ds-react": "^7.24.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "prettier": "prettier --write ."
   },
   "dependencies": {
-    "@navikt/ds-css": "^7.24.0",
+    "@navikt/ds-css": "^7.25.1",
     "@navikt/ds-react": "^7.24.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,17 @@
 import Header from './components/Header';
 import MainPage from './page/MainPage';
+import { Theme } from '@navikt/ds-react/Theme';
+import '@navikt/ds-css/darkside';
+import { useState } from 'react';
 
 function App() {
+  const [theme, setTheme] = useState<'light' | 'dark'>('light');
   return (
     <>
-      <Header />
-      <MainPage />
+      <Theme theme={theme}>
+        <Header theme={theme} setTheme={setTheme} />
+        <MainPage />
+      </Theme>
     </>
   );
 }

--- a/src/components/DarksideButton.tsx
+++ b/src/components/DarksideButton.tsx
@@ -1,0 +1,29 @@
+import { Button } from '@navikt/ds-react';
+import { MoonIcon, SunIcon } from '@navikt/aksel-icons';
+
+const DarksideButton = ({
+  theme,
+  setTheme,
+}: {
+  theme: 'dark' | 'light';
+  setTheme: (value: 'dark' | 'light') => void;
+}) =>
+  theme === 'dark' ? (
+    <Button
+      variant="tertiary-neutral"
+      icon={<SunIcon title="Switch to light theme" />}
+      onClick={() => {
+        setTheme('light');
+      }}
+    />
+  ) : (
+    <Button
+      variant="tertiary-neutral"
+      icon={<MoonIcon title="Switch to dark theme" />}
+      onClick={() => {
+        setTheme('dark');
+      }}
+    />
+  );
+
+export default DarksideButton;

--- a/src/components/Form.module.less
+++ b/src/components/Form.module.less
@@ -1,5 +1,7 @@
+@import "@navikt/ds-tokens/darkside-css";
+
 .formContainer {
-  background-color: var(--color-pink-light);
+  background-color: var(--ax-neutral-300);
   padding: var(--spacing-medium) var(--spacing-small);
   margin: var(--spacing-xlarge) 0;
   gap: var(--spacing-small);

--- a/src/components/Header.module.less
+++ b/src/components/Header.module.less
@@ -1,5 +1,7 @@
+@import "@navikt/ds-tokens/darkside-css";
+
 .headerContainer {
   display: flex;
   justify-content: space-between;
-  border-bottom: var(--border-mini) solid var(--color-black);
+  border-bottom: var(--border-mini) solid var(--ax-neutral-000);
 }

--- a/src/components/Header.module.less
+++ b/src/components/Header.module.less
@@ -1,3 +1,5 @@
 .headerContainer {
+  display: flex;
+  justify-content: space-between;
   border-bottom: var(--border-mini) solid var(--color-black);
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,10 +1,18 @@
 import Logo from './Logo.tsx';
+import DarksideButton from './DarksideButton.tsx';
 import styles from './Header.module.less';
 
-const Header = () => {
+const Header = ({
+  theme,
+  setTheme,
+}: {
+  theme: 'dark' | 'light';
+  setTheme: (value: 'dark' | 'light') => void;
+}) => {
   return (
     <header className={styles.headerContainer}>
       <Logo />
+      <DarksideButton theme={theme} setTheme={setTheme} />
     </header>
   );
 };

--- a/src/components/Logo.module.less
+++ b/src/components/Logo.module.less
@@ -1,6 +1,8 @@
+@import "@navikt/ds-tokens/darkside-css";
+
 .logoContainer {
   padding: var(--spacing-small);
   font-size: var(--font-size-large);
   font-weight: var(--font-weight-bold);
-  color: var(--color-red);
+  color: var(--ax-danger-800);
 }

--- a/src/components/Logo.module.less
+++ b/src/components/Logo.module.less
@@ -1,5 +1,4 @@
 .logoContainer {
-  margin: 0 auto;
   padding: var(--spacing-small);
   font-size: var(--font-size-large);
   font-weight: var(--font-weight-bold);

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -1,1 +1,2 @@
 declare module '@navikt/ds-css';
+declare module '@navikt/ds-css/darkside';

--- a/src/index.less
+++ b/src/index.less
@@ -31,4 +31,5 @@ body {
   margin: 0 auto;
   font-weight: var(--font-weight-regular);
   color: var(--color-black);
+  height: 100%;
 }

--- a/src/index.less
+++ b/src/index.less
@@ -1,4 +1,5 @@
 @import url("https://fonts.googleapis.com/css2?family=Source+Sans+3:wght@400;500;700&display=swap");
+@import "@navikt/ds-tokens/darkside-css";
 
 :root {
   --max-width-page: 800px;
@@ -15,21 +16,10 @@
   --font-weight-regular: 400;
   --font-weight-medium: 500;
   --font-weight-bold: 700;
-
-  --color-black: #333;
-  --color-white: #fff;
-  --color-red: #c30000;
-  --color-pink-light: #ffe6e6;
-
-  --color-background-page: #f0f0f0;
 }
 
 html,
 body {
-  font-family: "Source Sans 3", system-ui, Avenir, Helvetica, Arial, sans-serif;
-  background-color: var(--color-background-page);
   margin: 0 auto;
-  font-weight: var(--font-weight-regular);
-  color: var(--color-black);
   height: 100%;
 }

--- a/src/page/MainPage.module.less
+++ b/src/page/MainPage.module.less
@@ -4,7 +4,7 @@
 }
 
 .titleContainer {
-  padding: 0 var(--spacing-small);
+  padding: 0 var(--spacing-small) var(--spacing-xlarge);
 }
 
 .title {


### PR DESCRIPTION
## **Beskrivelse**

Implementert darkside.

## **Endringer**
- Implementert Darkside
- Gått over til navikt sin fargestyling
- Gått over til navikt sin fontstyling

## **Skjermbilde - desktop horizontal lightmode**
<img width="1481" height="835" alt="image" src="https://github.com/user-attachments/assets/f68ddbbd-bf88-48d9-a152-b18e7e8f8719" />

## **Skjermbilde - desktop horizontal lightmode**
<img width="1472" height="855" alt="image" src="https://github.com/user-attachments/assets/09cfe4dd-0c12-4577-8b09-48362a7a8493" />


## **Testing**
- [x] Testet responsivitet på mobil, nettbrett og desktop.
- [x] Verifisert fargekontraster.









